### PR TITLE
Fixes for MSVC build generator

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -108,7 +108,7 @@ class Vallus:
                 description = 'BOOTSTRAP')
         all_includes = self._includes + [path.join('deps', i, 'include') for i in self._depends]
         if(args.boost_dir):
-            all_includes.append(path.join(args.boost_dir, 'include'))
+            all_includes.append(args.boost_dir)
         ninja.rule('cxx',
                 command = tools.compiler_command(
                         command = compiler,

--- a/toolchain/llvm.py
+++ b/toolchain/llvm.py
@@ -43,7 +43,7 @@ class Toolchain:
         return ' '.join(itertools.chain(
                     [command],
                     ['-MMD','-MF ' + dep_output],
-                    ['-c', '-stdlib=libc++', '-std=c++11'],
+                    ['-c', '-stdlib=libc++', '-std=c++11', '-pthread'],
                     self.debug_flags() if debug else self.opt_flags(),
                     self.lto_flags() if lto and not debug else [],
                     warnings,
@@ -66,7 +66,7 @@ class Toolchain:
                        output = ''):
         return ' '.join(itertools.chain(
                     [command],
-                    ['-stdlib=libc++', '-std=c++11'],
+                    ['-stdlib=libc++', '-std=c++11', '-pthread'],
                     self.lto_flags() if lto and not debug else [],
                     (self.libpath(p) for p in libpaths),
                     [extraflags],

--- a/toolchain/llvm.py
+++ b/toolchain/llvm.py
@@ -43,7 +43,7 @@ class Toolchain:
         return ' '.join(itertools.chain(
                     [command],
                     ['-MMD','-MF ' + dep_output],
-                    ['-c', '-stdlib=libc++', '-std=c++11', '-pthread'],
+                    ['-c', '-stdlib=libc++', '-std=c++11'],
                     self.debug_flags() if debug else self.opt_flags(),
                     self.lto_flags() if lto and not debug else [],
                     warnings,
@@ -66,7 +66,7 @@ class Toolchain:
                        output = ''):
         return ' '.join(itertools.chain(
                     [command],
-                    ['-stdlib=libc++', '-std=c++11', '-pthread'],
+                    ['-stdlib=libc++', '-std=c++11'],
                     self.lto_flags() if lto and not debug else [],
                     (self.libpath(p) for p in libpaths),
                     [extraflags],

--- a/toolchain/ms.py
+++ b/toolchain/ms.py
@@ -46,7 +46,7 @@ class Toolchain:
                     (self.dep_include(i) for i in includes),
                     (self.define(*kv) for kv in defines),
                     [extraflags],
-                    ['/Fo' + output]
+                    ['/Fo' + output],
                     [input]
                 ))
 
@@ -62,9 +62,9 @@ class Toolchain:
         return ' '.join(itertools.chain(
                     [command],
                     ['/NOLOGO'],
-                    (self.libpath(p) for p in libpaths)
+                    (self.libpath(p) for p in libpaths),
                     [extraflags],
-                    ['/OUT:' + output]
+                    ['/OUT:' + output],
                     [input],
                     (self.library(l) for l in libraries)
                 ))
@@ -78,8 +78,7 @@ class Toolchain:
         return ' '.join(itertools.chain(
                     [command],
                     ['/NOLOGO'],
-                    self.archiver_lto_flags() if lto and not debug else [],
-                    ['/OUT:' + output]
+                    ['/OUT:' + output],
                     [extraflags],
                     [input]
                 ))
@@ -99,9 +98,9 @@ class Toolchain:
         return output + '.dll'
 
     def include(self, i):
-        return '/I' + d;
+        return '/I' + i;
     def dep_include(self, i):
-        return '/I' + d;
+        return '/I' + i;
     def define(self, k, v=None):
         return '/D' + (k + '=' + v if v else k)
     def library(self, l):

--- a/toolchain/ms.py
+++ b/toolchain/ms.py
@@ -63,6 +63,7 @@ class Toolchain:
                     [command],
                     ['/NOLOGO'],
                     (self.libpath(p) for p in libpaths),
+                    self.linker_lto_flags() if lto and not debug else [],
                     [extraflags],
                     ['/OUT:' + output],
                     [input],
@@ -114,8 +115,8 @@ class Toolchain:
         return ['/MD', '/O2', '/Oy-', '/Oi']
     def compiler_lto_flags(self):
         return ['/GL']
-    def archiver_lto_flags(self):
-        return []
+    def linker_lto_flags(self):
+        return ['/LTCG']
 
     def ninja_deps_style(self):
         return 'msvc'


### PR DESCRIPTION
There were a few errors in `ms.py` and also `--boost-dir` assumes that there is an `include` directory in the Boost distribution. This isn't the case in the Windows distribution so I removed it, I figure other platforms can specify the include directory, but maybe that's not a good solution.

I'm interested in using Nonius but I need MSVC support, there's a few build errors too which I'll look at next.
